### PR TITLE
Restructuring

### DIFF
--- a/interface/SelfManagedTkInterrface.py
+++ b/interface/SelfManagedTkInterrface.py
@@ -1,0 +1,74 @@
+from interface.Interface import Interface
+from interface.Input import Input
+from typing import Callable, Tuple
+from PIL import Image, ImageTk
+import config
+import tkinter as tk
+
+
+class SelfManagedTkInterface(Interface, Input):
+
+    BUTTON_W = 15
+    BUTTON_H = 6
+
+    def __init__(self, on_key_left: Callable, on_key_right: Callable,
+                 on_key_up: Callable, on_key_down: Callable, on_key_a: Callable, on_key_b: Callable,
+                 on_rotary_increase: Callable, on_rotary_decrease: Callable,
+                 resolution: Tuple[int, int], background: Tuple[int, int, int]):
+        Input.__init__(self, on_key_left, on_key_right, on_key_up, on_key_down, on_key_a, on_key_b,
+                       on_rotary_increase, on_rotary_decrease)
+        self.__on_key_left = on_key_left
+        self.__on_key_right = on_key_right
+        self.__on_key_up = on_key_up
+        self.__on_key_down = on_key_down
+        self.__on_key_a = on_key_a
+        self.__on_key_b = on_key_b
+        self.__on_rotary_increase = on_rotary_increase
+        self.__on_rotary_decrease = on_rotary_decrease
+        self.__resolution = resolution
+        self.__background = background
+        self.__image = Image.new('RGB', resolution, background)
+
+        self.__root = tk.Tk()
+        self.__root.title('PiBoy - Simulator')
+        self.__root.configure(bg='#%02x%02x%02x' % config.ACCENT_DARK)
+        self.__image_tk = ImageTk.PhotoImage(self.__image)
+        self.__label = tk.Label(self.__root, image=self.__image_tk)
+        self.__label.grid(row=0, column=0, rowspan=4)
+
+        button_left = tk.Button(self.__root, width=self.BUTTON_W, height=self.BUTTON_H, text='left',
+                                command=self.__on_key_left)
+        button_left.grid(row=1, column=1)
+        button_up = tk.Button(self.__root, width=self.BUTTON_W, height=self.BUTTON_H, text='up',
+                              command=self.__on_key_up)
+        button_up.grid(row=0, column=2)
+        button_right = tk.Button(self.__root, width=self.BUTTON_W, height=self.BUTTON_H, text='right',
+                                 command=self.__on_key_right)
+        button_right.grid(row=1, column=3)
+        button_down = tk.Button(self.__root, width=self.BUTTON_W, height=self.BUTTON_H, text='down',
+                                command=self.__on_key_down)
+        button_down.grid(row=2, column=2)
+        button_a = tk.Button(self.__root, width=self.BUTTON_W, height=self.BUTTON_H, text='button a',
+                             command=self.__on_key_a)
+        button_a.grid(row=2, column=4)
+        button_b = tk.Button(self.__root, width=self.BUTTON_W, height=self.BUTTON_H, text='button b',
+                             command=self.__on_key_b)
+        button_b.grid(row=2, column=5)
+        button_decrease = tk.Button(self.__root, width=self.BUTTON_W, height=self.BUTTON_H, text='-',
+                                    command=self.__on_rotary_decrease)
+        button_decrease.grid(row=0, column=4)
+        button_increase = tk.Button(self.__root, width=self.BUTTON_W, height=self.BUTTON_H, text='+',
+                                    command=self.__on_rotary_increase)
+        button_increase.grid(row=0, column=5)
+
+    def show(self, image: Image, x0, y0):
+        self.__image.paste(image, (x0, y0))
+        self.__image_tk = ImageTk.PhotoImage(self.__image)
+        self.__label.configure(image=self.__image_tk)
+
+    def close(self):
+        pass
+
+    def run(self):
+        """blocking function to actually run the UI"""
+        self.__root.mainloop()

--- a/piboy.py
+++ b/piboy.py
@@ -17,20 +17,12 @@ from datetime import datetime
 
 class AppState:
 
-    __INSTANCE = None
-
     def __init__(self, resolution: Tuple[int, int], background: Tuple[int, int, int]):
         self.__resolution = resolution
         self.__background = background
         self.__image_buffer = self.__init_buffer()
         self.__apps = []
         self.__active_app = 0
-
-    @classmethod
-    def instance(cls) -> 'AppState':
-        if cls.__INSTANCE is None:
-            cls.__INSTANCE = cls(config.RESOLUTION, config.BACKGROUND)
-        return cls.__INSTANCE
 
     def __init_buffer(self) -> Image:
         return Image.new('RGB', self.__resolution, self.__background)
@@ -69,89 +61,58 @@ class AppState:
         if self.__active_app < 0:
             self.__active_app = len(self.__apps) - 1
 
+    def watch_function(self):
+        while True:
+            now = datetime.now()
+            # wait for next second
+            time.sleep(1.0 - now.microsecond / 1000000.0)
 
-def on_key_left():
-    AppState.instance().active_app.on_key_left()
-    update_display(partial=True)
+            # draw the complete footer to remove existing clock display
+            image, x0, y0 = draw_footer(self.image_buffer)
+            INTERFACE.show(image, x0, y0)
 
-
-def on_key_right():
-    AppState.instance().active_app.on_key_right()
-    update_display(partial=True)
-
-
-def on_key_up():
-    AppState.instance().active_app.on_key_up()
-    update_display(partial=True)
-
-
-def on_key_down():
-    AppState.instance().active_app.on_key_down()
-    update_display(partial=True)
-
-
-def on_key_a():
-    AppState.instance().active_app.on_key_a()
-    update_display(partial=True)
-
-
-def on_key_b():
-    AppState.instance().active_app.on_key_b()
-    update_display(partial=True)
-
-
-def on_rotary_increase():
-    AppState.instance().active_app.on_app_leave()
-    AppState.instance().next_app()
-    update_display(partial=False)
-    AppState.instance().active_app.on_app_enter()
-
-
-def on_rotary_decrease():
-    AppState.instance().active_app.on_app_leave()
-    AppState.instance().previous_app()
-    update_display(partial=False)
-    AppState.instance().active_app.on_app_enter()
-
-
-INTERFACE: Interface
-INPUT: Input
-
-if config.DEV_MODE:
-    from interface.TkInterface import TkInterface
-
-    __tk = TkInterface(on_key_left, on_key_right, on_key_up, on_key_down, on_key_a, on_key_b,
-                       on_rotary_increase, on_rotary_decrease, config.RESOLUTION, config.BACKGROUND)
-    INTERFACE = __tk
-    INPUT = __tk
-else:
-    from interface.ILI9486Interface import ILI9486Interface
-    from interface.GPIOInput import GPIOInput
-
-    INTERFACE = ILI9486Interface(config.FLIP_DISPLAY)
-    INPUT = GPIOInput(config.LEFT_PIN, config.UP_PIN, config.RIGHT_PIN, config.DOWN_PIN, config.A_PIN, config.B_PIN,
-                      config.CLK_PIN, config.DT_PIN, config.SW_PIN,
-                      on_key_left, on_key_right, on_key_up, on_key_down, on_key_a, on_key_b,
-                      on_rotary_increase, on_rotary_decrease)
-
-
-def watch_function():
-    while True:
-        now = datetime.now()
-        # wait for next second
-        time.sleep(1.0 - now.microsecond / 1000000.0)
-
-        # draw the complete footer to remove existing clock display
-        image, x0, y0 = draw_footer(AppState.instance().image_buffer)
+    def update_display(self, partial=False):
+        """Draw call that handles the complete cycle of drawing a new image to the display."""
+        image = self.clear_buffer()
+        image = draw_base(image, self)
+        image, x0, y0 = self.active_app.draw(image, partial)
         INTERFACE.show(image, x0, y0)
 
+    def on_key_left(self):
+        self.active_app.on_key_left()
+        self.update_display(partial=True)
 
-def update_display(partial=False):
-    """Draw call that handles the complete cycle of drawing a new image to the display."""
-    image = AppState.instance().clear_buffer()
-    image = draw_base(image)
-    image, x0, y0 = AppState.instance().active_app.draw(image, partial)
-    INTERFACE.show(image, x0, y0)
+    def on_key_right(self):
+        self.active_app.on_key_right()
+        self.update_display(partial=True)
+
+    def on_key_up(self):
+        self.active_app.on_key_up()
+        self.update_display(partial=True)
+
+    def on_key_down(self):
+        self.active_app.on_key_down()
+        self.update_display(partial=True)
+
+    def on_key_a(self):
+        self.active_app.on_key_a()
+        self.update_display(partial=True)
+
+    def on_key_b(self):
+        self.active_app.on_key_b()
+        self.update_display(partial=True)
+
+    def on_rotary_increase(self):
+        self.active_app.on_app_leave()
+        self.next_app()
+        self.update_display(partial=False)
+        self.active_app.on_app_enter()
+
+    def on_rotary_decrease(self):
+        self.active_app.on_app_leave()
+        self.previous_app()
+        self.update_display(partial=False)
+        self.active_app.on_app_enter()
 
 
 def draw_footer(image: Image) -> (Image, int, int):
@@ -169,13 +130,14 @@ def draw_footer(image: Image) -> (Image, int, int):
     draw.rectangle(start + end, fill=config.ACCENT_DARK)
     _, _, text_width, text_height = font.getbbox(date_str)
     text_padding = (footer_height - text_height) / 2
-    draw.text((width - footer_side_offset - text_padding - text_width, height - footer_height - footer_bottom_offset +
-               text_padding), date_str, config.ACCENT, font=font)
+    draw.text(
+        (width - footer_side_offset - text_padding - text_width, height - footer_height - footer_bottom_offset +
+         text_padding), date_str, config.ACCENT, font=font)
     x0, y0 = start
     return image.crop(start + end), x0, y0
 
 
-def draw_header(image: Image) -> (Image, int, int):
+def draw_header(image: Image, state: AppState) -> (Image, int, int):
     width, height = config.RESOLUTION
     vertical_line = 5  # vertical limiter line
     header_top_offset = config.APP_TOP_OFFSET - vertical_line  # base for header
@@ -198,13 +160,12 @@ def draw_header(image: Image) -> (Image, int, int):
     # draw app short name header
     font = config.FONT_HEADER
     max_text_width = width - (2 * header_side_offset)
-    app_text_width = sum(font.getbbox(app.title)[2] for app in AppState.instance().apps)\
-        + (len(AppState.instance().apps) - 1) * app_spacing
+    app_text_width = sum(font.getbbox(app.title)[2] for app in state.apps) + (len(state.apps) - 1) * app_spacing
     cursor = header_side_offset + (max_text_width - app_text_width) / 2
-    for app in AppState.instance().apps:
+    for app in state.apps:
         _, _, text_width, text_height = font.getbbox(app.title)
         draw.text((cursor, header_top_offset - text_height - app_padding), app.title, config.ACCENT, font=font)
-        if app is AppState.instance().active_app:
+        if app is state.active_app:
             start = (cursor - app_padding, header_top_offset - vertical_line)
             end = (cursor - app_padding, header_top_offset)
             draw.line(start + end, fill=config.ACCENT)
@@ -222,28 +183,52 @@ def draw_header(image: Image) -> (Image, int, int):
     return image.crop(partial_start + partial_end), x0, y0
 
 
-def draw_base(image: Image) -> Image:
-    draw_header(image)
+def draw_base(image: Image, state: AppState) -> Image:
+    draw_header(image, state)
     draw_footer(image)
     return image
 
 
 if __name__ == '__main__':
-    AppState.instance().add_app(FileManagerApp()) \
+    app_state = AppState(config.RESOLUTION, config.BACKGROUND)
+    app_state.add_app(FileManagerApp()) \
         .add_app(NullApp('DATA')) \
         .add_app(NullApp('STAT')) \
         .add_app(NullApp('RAD')) \
         .add_app(DebugApp()) \
-        .add_app(ClockApp(update_display)) \
-        .add_app(MapApp(update_display, IPLocationProvider(apply_inaccuracy=True), OSMTileProvider()))
+        .add_app(ClockApp(app_state.update_display)) \
+        .add_app(MapApp(app_state.update_display, IPLocationProvider(apply_inaccuracy=True), OSMTileProvider()))
+
+    INTERFACE: Interface
+    INPUT: Input
+
+    if config.DEV_MODE:
+        from interface.TkInterface import TkInterface
+
+        __tk = TkInterface(app_state.on_key_left, app_state.on_key_right, app_state.on_key_up, app_state.on_key_down,
+                           app_state.on_key_a, app_state.on_key_b,
+                           app_state.on_rotary_increase, app_state.on_rotary_decrease,
+                           config.RESOLUTION, config.BACKGROUND)
+        INTERFACE = __tk
+        INPUT = __tk
+    else:
+        from interface.ILI9486Interface import ILI9486Interface
+        from interface.GPIOInput import GPIOInput
+
+        INTERFACE = ILI9486Interface(config.FLIP_DISPLAY)
+        INPUT = GPIOInput(config.LEFT_PIN, config.UP_PIN, config.RIGHT_PIN, config.DOWN_PIN, config.A_PIN, config.B_PIN,
+                          config.CLK_PIN, config.DT_PIN, config.SW_PIN,
+                          app_state.on_key_left, app_state.on_key_right, app_state.on_key_up, app_state.on_key_down,
+                          app_state.on_key_a, app_state.on_key_b,
+                          app_state.on_rotary_increase, app_state.on_rotary_decrease, )
 
     # initial draw
-    update_display()
-    AppState.instance().active_app.on_app_enter()
+    app_state.update_display()
+    app_state.active_app.on_app_enter()
 
     try:
         # blocking function that updates the clock
-        watch_function()
+        app_state.watch_function()
     except KeyboardInterrupt:
         pass
     finally:

--- a/piboy.py
+++ b/piboy.py
@@ -253,7 +253,7 @@ if __name__ == '__main__':
     app_state.active_app.on_app_enter()
 
     try:
-        # blocking function that updates th clock
+        # blocking function that updates the clock
         app_state.watch_function(INTERFACE)
     except KeyboardInterrupt:
         pass

--- a/piboy_dev.py
+++ b/piboy_dev.py
@@ -1,0 +1,82 @@
+import config
+from app.ClockApp import ClockApp
+from app.DebugApp import DebugApp
+from app.FileManagerApp import FileManagerApp
+from app.MapApp import MapApp
+from app.NullApp import NullApp
+from data.IPLocationProvider import IPLocationProvider
+from data.OSMTileProvider import OSMTileProvider
+from interface import Interface, Input
+from interface.SelfManagedTkInterrface import SelfManagedTkInterface
+from piboy import AppState
+import threading
+
+"""
+This pi-boy script uses the SelfManagedTkInterface, which follows the usual mainloop approach. This makes it compatible
+with MacOS and maybe other desktop environments that require UI draw calls from a main thread only. Other systems may
+continue to use the other script, that is also made for the raspberry pi.
+"""
+if __name__ == '__main__':
+    INTERFACE: Interface
+    INPUT: Input
+
+    app_state = AppState(config.RESOLUTION, config.BACKGROUND)
+
+    # wrapping key functions with local interface instance
+    def on_key_left():
+        app_state.on_key_left(INTERFACE)
+
+    def on_key_right():
+        app_state.on_key_right(INTERFACE)
+
+    def on_key_up():
+        app_state.on_key_up(INTERFACE)
+
+    def on_key_down():
+        app_state.on_key_down(INTERFACE)
+
+    def on_key_a():
+        app_state.on_key_a(INTERFACE)
+
+    def on_key_b():
+        app_state.on_key_b(INTERFACE)
+
+    def on_rotary_increase():
+        app_state.on_rotary_increase(INTERFACE)
+
+    def on_rotary_decrease():
+        app_state.on_rotary_decrease(INTERFACE)
+
+    def update_display(partial=False):
+        app_state.update_display(INTERFACE, partial)
+
+    app_state.add_app(FileManagerApp()) \
+        .add_app(NullApp('DATA')) \
+        .add_app(NullApp('STAT')) \
+        .add_app(NullApp('RAD')) \
+        .add_app(DebugApp()) \
+        .add_app(ClockApp(update_display)) \
+        .add_app(MapApp(update_display, IPLocationProvider(apply_inaccuracy=True), OSMTileProvider()))
+
+    __tk = SelfManagedTkInterface(on_key_left, on_key_right, on_key_up, on_key_down, on_key_a, on_key_b,
+                                  on_rotary_increase, on_rotary_decrease, config.RESOLUTION, config.BACKGROUND)
+    INTERFACE = __tk
+    INPUT = __tk
+
+    # initial draw
+    app_state.update_display(INTERFACE)
+    app_state.active_app.on_app_enter()
+
+    # watch function has to run in the background, because Tkinter mainloop must be in the main thread
+    threading.Thread(target=app_state.watch_function, args=(INTERFACE, ), daemon=True).start()
+
+    try:
+        # blocking run function
+        __tk.run()
+        # blocking function that updates the clock
+        app_state.watch_function(INTERFACE)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        INTERFACE.close()
+        INPUT.close()


### PR DESCRIPTION
Due to a restriction in macOS, the draw calls for Tkinter have to be made from the main thread.

However, the original pi-boy script and first TkInterface implementation were made with focus on the raspberry pi, that does not need the TkInterface but runs the blocking watch function instead.

To solve this, the base script has been restructured to make it importable into an alternative script. This alternative script has only the bare minimum inside itself and imports most of its stuff. It works very well on macOS, however the rendered image might cause flickering on Windows. But the base script still works on Windows and can be used as usual.